### PR TITLE
delete getBattery instead of setting it to undefined

### DIFF
--- a/js/content_script.js
+++ b/js/content_script.js
@@ -1,5 +1,5 @@
 (function() {
     var s = document.createElement('script');
-    s.textContent = "navigator.getBattery = undefined;document.currentScript.removeChild(document.currentScript);";
+    s.textContent = "delete navigator.getBattery;document.currentScript.removeChild(document.currentScript);";
     (document.head || document.documentElement).appendChild(s);
 })()


### PR DESCRIPTION
To support feature detectors which use `navigator.hasOwnProperty('getBattery')`